### PR TITLE
返信した過去のトークも一緒に送信する機能の追加

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -154,10 +154,6 @@ bot.command :gpt do |event, *args|
   request["Authorization"] = "Bearer #{openai_key}"
 
   body_messages = get_body_messages(event.message, bot)
-  body_messages.push({
-    "role": "user",
-    "content": args.join(' ')
-  })
 
   if body_messages.length > max_replay_length
     event.message.reply!("🙇 #{max_replay_length}回以上の会話はできません!!")


### PR DESCRIPTION
## 変更内容
* botにgptコマンドを使用したとき、質問者に返信で応答するよう変更
* 返信でgptコマンドを使用したとき、その返信を再帰的に読んでpromptを送信するよう変更


## 関連PR
* https://github.com/Yamada-Factory/infra/pull/4