### PR TITLE
GPTを叩く時のTimeoutを伸ばす

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -148,6 +148,7 @@ bot.command :gpt do |event, *args|
 
   https = Net::HTTP.new(url.host, url.port)
   https.use_ssl = true
+  https.read_timeout = 120
 
   request = Net::HTTP::Post.new(url)
   request["Content-Type"] = "application/json"

--- a/bot.rb
+++ b/bot.rb
@@ -179,8 +179,8 @@ bot.command :gpt do |event, *args|
 
     # discordの投稿に返信する
     event.message.reply!(data['choices'][0]['message']['content'])
-  rescue Net::ReadTimeout => e
-    event.message.reply!('タイムアウトエラーが発生しました')
+  rescue => e
+    event.message.reply!("🚨 #{e.class} 🚨")
   end
 
   return

--- a/bot.rb
+++ b/bot.rb
@@ -168,16 +168,20 @@ bot.command :gpt do |event, *args|
   }
   request.body = JSON.dump(body)
 
-  response = https.request(request)
-  if response.code != '200'
-    event.respond('エラーが発生しました' + response.read_body)
-    return
+  begin
+    response = https.request(request)
+    if response.code != '200'
+      event.respond('エラーが発生しました' + response.read_body)
+      return
+    end
+
+    data = JSON.parse(response.read_body)
+
+    # discordの投稿に返信する
+    event.message.reply!(data['choices'][0]['message']['content'])
+  rescue Net::ReadTimeout => e
+    event.message.reply!('タイムアウトエラーが発生しました')
   end
-
-  data = JSON.parse(response.read_body)
-
-  # discordの投稿に返信する
-  event.message.reply!(data['choices'][0]['message']['content'])
 
   return
 end


### PR DESCRIPTION
### 内容
- openAIのchatGPTを叩くにタイムアウトになるまでの時間を60秒から120秒に変更
  - https://docs.ruby-lang.org/ja/2.7.0/method/Net=3a=3aHTTP/i/read_timeout.html
- エラーが発生したときに「🚨 #{e.class} 🚨」を返信するように変更
